### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ git clone https://github.com/Domexx/ares-habbo-backend.git
 ```console
 $ cd ares-habbo-backend
 ```
-##### 3. Copy dotenv config.
+##### 3. Rename dotenv config.
 ```console
 $ cp .env.example .env 
 ```


### PR DESCRIPTION
`cp .env.example .env` does not copy the config, the command just renames the files.

`cp .env.example .env.example.backup` would copy the file :).

👋🏼 